### PR TITLE
Skip reading response body on request error

### DIFF
--- a/client.go
+++ b/client.go
@@ -26,11 +26,12 @@ func CallWithCodec(cc rpc.ClientCodec, method string, args interface{}, resp int
 	if err := cc.ReadResponseHeader(&response); err != nil {
 		return err
 	}
+	if response.Error != "" {
+		cc.ReadResponseBody(nil)
+		return rpc.ServerError(response.Error)
+	}
 	if err := cc.ReadResponseBody(resp); err != nil {
 		return err
-	}
-	if response.Error != "" {
-		return rpc.ServerError(response.Error)
 	}
 	return nil
 }


### PR DESCRIPTION
When calling an RPC method, if an error is returned, then only the response header should be decoded, and the body should be discarded. This was partially masked by the data type of the response during a `CallWithCodec`, because the default response body when errors are encountered is the empty `struct{}`: https://github.com/golang/go/blob/master/src/net/rpc/server.go#L358. I ran into this in cases where the response is type `*string`, in which case the empty struct is attempted to be decoded into it, and thus fails decoding. The specific error in msgpack that this generates would be:

```
codec.decoder: readContainerLen: Unrecognized descriptor byte: hex: 80, dec: 128
```

In msgpack, [0x80](https://github.com/msgpack/msgpack/blob/master/spec.md#overview) is the start of a fixmap with size 0.

TL;DR: Call `ReadResponseBody(nil)` instead of `ReadResponseBody(resp)` if the method returns a non-nil error to read the response to nowhere.