### PR TITLE
Make v2 go module

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -6,7 +6,7 @@ import (
 	"net/rpc"
 	"sync"
 
-	"github.com/hashicorp/go-msgpack/codec"
+	"github.com/hashicorp/go-msgpack/v2/codec"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/hashicorp/net-rpc-msgpackrpc/v2
+
+go 1.19
+
+require (
+	github.com/hashicorp/go-msgpack/v2 v2.0.0
+	github.com/hashicorp/go-multierror v1.1.1
+)
+
+require github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-msgpack/v2 v2.0.0 h1:c1fiLq1LNghmLOry1ipGhvLDi+/zEoaEP2JrE1oFJ9s=
+github.com/hashicorp/go-msgpack/v2 v2.0.0/go.mod h1:JIxYkkFJRDDRSoWQBSh7s9QAVThq+82iWmUpmE4jKak=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190424220101-1e8e1cfdf96b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=


### PR DESCRIPTION
Importing this package, since it was not module-aware, fetched `github.com/hashicorp/go-msgpack@v1.1.5` by default.

However, https://github.com/hashicorp/go-msgpack retracted `v1.1.5` which was causing issues with compatibility and re-released `github.com/hashicorp/go-msgpack/v2` instead. [(source)](https://github.com/hashicorp/go-msgpack/releases/tag/v1.1.6) 

Now go-get-ing this repo fetches `v0.5.5`:
```
> go get github.com/hashicorp/net-rpc-msgpackrpc
go: added github.com/hashicorp/errwrap v1.0.0
go: added github.com/hashicorp/go-msgpack v0.5.5
go: added github.com/hashicorp/go-multierror v1.1.1
go: added github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69
```
but also faces a problem where projects importing this repo may be implicitly relying on `go-msgpack v1.1.5`'s codec.

The best solution is to make a `v2` split in this repo as well, so that users can opt in to the old behavior (now tagged as `go-msgpack/v2`).
