### PR TITLE
IND-3837 dependabot enabling, changelog file addition

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[chore] : "
+      
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[chore] : "

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,17 +2,33 @@
 # SPDX-License-Identifier: MPL-2.0
 
 version: 2
+
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+      day: "sunday"
     commit-message:
       prefix: "[chore] : "
-      
-  - package-ecosystem: gomod
-    directory: /
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+      day: "sunday"
     commit-message:
       prefix: "[chore] : "
+    groups:
+      go:
+        patterns:
+          - "*"
+        applies-to: "version-updates"
+      go-security:
+        patterns:
+          - "*"
+        applies-to: "security-updates"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased
+
+### Improvements
+
+### Changes
+
+### Fixed
+
+### Security


### PR DESCRIPTION
- As per the memo: https://go.hashi.co/memo/eng-004,
Enabling the dependabot for identifying and updating the security and version updates in the repositories rather handling it manually.
- Adding the CHANGELOG.md file to maintain standardisation across OSS core libraries